### PR TITLE
Removed ExpressibleByIntegerLiteral and SignedNumber conformance from 'Numeric' protocol

### DIFF
--- a/IMGLYColorPicker/Classes/ColorValues.swift
+++ b/IMGLYColorPicker/Classes/ColorValues.swift
@@ -18,7 +18,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-protocol Numeric: Comparable, ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, SignedNumber {
+protocol Numeric: Comparable, ExpressibleByFloatLiteral {
     var value: Double { set get }
     init(_ value: Double)
 }


### PR DESCRIPTION
The new Xcode 9 beta throws a Swift compiler error when I try to build a project which is dependent on this library. I found that removing these two protocols fixed the issue.